### PR TITLE
update templates to use generateApplicationUUID

### DIFF
--- a/client_portal/directory/directory.cue
+++ b/client_portal/directory/directory.cue
@@ -6,11 +6,11 @@ import (
 
 roleClassMap: {[string]: directoryv1.#Role} & {
 	Admin: {
-		id: {{ generateWorkspaceUUID "AdminRoleClass" | quote }}
+		id: {{ generateApplicationUUID "AdminRoleClass" | quote }}
 		name: "Admin"
 	}
 	Staff: {
-		id: {{ generateWorkspaceUUID "StaffRoleClass" | quote }}
+		id: {{ generateApplicationUUID "StaffRoleClass" | quote }}
 		name: "Staff"
 	}
 }
@@ -22,13 +22,13 @@ roleClassList: [...directoryv1.#RoleClass] & [
 
 roleMap: {[string]: directoryv1.#Role} & {
 	Admin: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "AdminRole" | quote }}
+		id: {{ generateApplicationUUID "AdminRole" | quote }}
 		name:        "Admin"
 		roleClassId: roleClassMap.Admin.id
 		policies: [policyList[0].id]
 	}
 	Staff: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "StaffRole" | quote }}
+		id: {{ generateApplicationUUID "StaffRole" | quote }}
 		name:        "Staff"
 		roleClassId: roleClassMap.Staff.id
 		policies: [policyList[1].id]
@@ -37,7 +37,7 @@ roleMap: {[string]: directoryv1.#Role} & {
 
 policyList: [...directoryv1.#Policy] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminPolicy" | quote }}
+		id: {{ generateApplicationUUID "AdminPolicy" | quote }}
 		name:   "admin"
 		permit: "allow"
 		actions: ["*"]
@@ -47,7 +47,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffPolicy" | quote }}
+		id: {{ generateApplicationUUID "StaffPolicy" | quote }}
 		name:   "default"
 		permit: "allow"
 		actions: ["get", "list"]
@@ -65,18 +65,18 @@ roleList: [
 
 groupList: [...directoryv1.#Group] & [
 	{
-		id: {{ generateWorkspaceUUID "InternalGroup" | quote }}
+		id: {{ generateApplicationUUID "InternalGroup" | quote }}
 		name: "internal"
 	},
 	{
-		id: {{ generateWorkspaceUUID "ExternalGroup" | quote }}
+		id: {{ generateApplicationUUID "ExternalGroup" | quote }}
 		name: "external"
 	},
 ]
 
 userList: [...directoryv1.#User] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminUser" | quote }}
+		id: {{ generateApplicationUUID "AdminUser" | quote }}
 		username:    "adminadmin"
 		displayName: "admin"
 		secret:      "adminadmin"
@@ -84,7 +84,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffUser" | quote }}
+		id: {{ generateApplicationUUID "StaffUser" | quote }}
 		username:    "staffstaff"
 		displayName: "staff"
 		secret:      "staffstaff"

--- a/client_portal/seed/seed.cue
+++ b/client_portal/seed/seed.cue
@@ -5,13 +5,13 @@ import (
 )
 
 users: {
-	jdoe: {{ generateWorkspaceUUID "User1" | quote }}
-	mdavis: {{ generateWorkspaceUUID "User2" | quote }}
+	jdoe: {{ generateApplicationUUID "User1" | quote }}
+	mdavis: {{ generateApplicationUUID "User2" | quote }}
 }
 
 clients: {
-	jdoe: {{ generateWorkspaceUUID "Client1" | quote }}
-	mdavis: {{ generateWorkspaceUUID "Client2" | quote }}
+	jdoe: {{ generateApplicationUUID "Client1" | quote }}
+	mdavis: {{ generateApplicationUUID "Client2" | quote }}
 }
 
 manifest.#TailorManifest & {
@@ -125,7 +125,7 @@ manifest.#TailorManifest & {
 				variables: {
 					jDoeId:   clients.jdoe
 					mDavisId: clients.mdavis
-					completedServiceRequestId: {{ generateWorkspaceUUID "ServiceRequest2" | quote }}
+					completedServiceRequestId: {{ generateApplicationUUID "ServiceRequest2" | quote }}
 				}
 			},
 			{
@@ -144,7 +144,7 @@ manifest.#TailorManifest & {
 					"""
 				variables: {
 					jDoeId: clients.jdoe
-					completedServiceRequestId: {{ generateWorkspaceUUID "ServiceRequest2" | quote }}
+					completedServiceRequestId: {{ generateApplicationUUID "ServiceRequest2" | quote }}
 				}
 			},
 		]

--- a/crm/directory/directory.cue
+++ b/crm/directory/directory.cue
@@ -6,15 +6,15 @@ import (
 
 userTypeMap: {[string]: directoryv1.#UserType} & {
 	Permanent: {
-		id:  {{ generateWorkspaceUUID "PermanentUserType" | quote }}
+		id:  {{ generateApplicationUUID "PermanentUserType" | quote }}
 		name: "Permanent"
 	}
 	Contract: {
-		id: {{ generateWorkspaceUUID "ContractUserType" | quote }}
+		id: {{ generateApplicationUUID "ContractUserType" | quote }}
 		name: "Contract"
 	}
 	Other: {
-		id: {{ generateWorkspaceUUID "OtherUserType" | quote }}
+		id: {{ generateApplicationUUID "OtherUserType" | quote }}
 		name: "Other"
 	}
 }
@@ -27,15 +27,15 @@ userTypeList: [...directoryv1.#UserType] & [
 
 roleClassMap: {[string]: directoryv1.#Role} & {
 	Admin: {
-		id: {{ generateWorkspaceUUID "AdminRoleClass" | quote }}
+		id: {{ generateApplicationUUID "AdminRoleClass" | quote }}
 		name: "Admin"
 	}
 	Staff: {
-		id: {{ generateWorkspaceUUID "StaffRoleClass" | quote }}
+		id: {{ generateApplicationUUID "StaffRoleClass" | quote }}
 		name: "Staff"
 	}
 	Manager: {
-		id: {{ generateWorkspaceUUID "ManagerRoleClass" | quote }}
+		id: {{ generateApplicationUUID "ManagerRoleClass" | quote }}
 		name: "Manager"
 	}
 }
@@ -48,19 +48,19 @@ roleClassList: [...directoryv1.#RoleClass] & [
 
 roleMap: {[string]: directoryv1.#Role} & {
 	Admin: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "AdminRole" | quote }}
+		id: {{ generateApplicationUUID "AdminRole" | quote }}
 		name:        "Admin"
 		roleClassId: roleClassMap.Admin.id
 		policies: [policyList[0].id]
 	}
 	Staff: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "StaffRole" | quote }}
+		id: {{ generateApplicationUUID "StaffRole" | quote }}
 		name:        "Staff"
 		roleClassId: roleClassMap.Staff.id
 		policies: [policyList[1].id]
 	}
 	Manager: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "ManagerRole" | quote }}
+		id: {{ generateApplicationUUID "ManagerRole" | quote }}
 		name:        "Manager"
 		roleClassId: roleClassMap.Manager.id
 		policies: [policyList[1].id]
@@ -69,7 +69,7 @@ roleMap: {[string]: directoryv1.#Role} & {
 
 policyList: [...directoryv1.#Policy] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminPolicy" | quote }}
+		id: {{ generateApplicationUUID "AdminPolicy" | quote }}
 		name:   "admin"
 		permit: "allow"
 		actions: ["*"]
@@ -79,7 +79,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffPolicy" | quote }}
+		id: {{ generateApplicationUUID "StaffPolicy" | quote }}
 		name:   "default"
 		permit: "allow"
 		actions: ["get", "list"]
@@ -89,7 +89,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerPolicy" | quote }}
+		id: {{ generateApplicationUUID "ManagerPolicy" | quote }}
 		name:   "customer"
 		permit: "deny"
 		actions: []
@@ -109,18 +109,18 @@ roleList: [
 
 groupList: [...directoryv1.#Group] & [
 	{
-		id: {{ generateWorkspaceUUID "InternalGroup" | quote }}
+		id: {{ generateApplicationUUID "InternalGroup" | quote }}
 		name: "internal"
 	},
 	{
-		id: {{ generateWorkspaceUUID "ExternalGroup" | quote }}
+		id: {{ generateApplicationUUID "ExternalGroup" | quote }}
 		name: "external"
 	},
 ]
 
 userList: [...directoryv1.#User] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminUser" | quote }}
+		id: {{ generateApplicationUUID "AdminUser" | quote }}
 		username:    "adminadmin"
 		displayName: "admin"
 		secret:      "adminadmin"
@@ -131,7 +131,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffUser" | quote }}
+		id: {{ generateApplicationUUID "StaffUser" | quote }}
 		username:    "staffstaff"
 		displayName: "staff"
 		secret:      "staffstaff"
@@ -142,7 +142,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerUser" | quote }}
+		id: {{ generateApplicationUUID "ManagerUser" | quote }}
 		username:    "managermanager"
 		displayName: "manager"
 		secret:      "managermanager"

--- a/crm/seed/seed.cue
+++ b/crm/seed/seed.cue
@@ -51,21 +51,21 @@ let accountMutationList = [
 
 accounts: {
 	account1: {
-		accountID: {{ generateWorkspaceUUID "Account1" | quote }}
+		accountID: {{ generateApplicationUUID "Account1" | quote }}
 		companyName:  "Globex Corporation"
 		contactName:  "Hank Scorpio"
 		emailAddress: "hank.scorpio@globex.com"
 		phoneNumber:  "(212) 555-1234"
 	}
 	account2: {
-		accountID: {{ generateWorkspaceUUID "Account2" | quote }}
+		accountID: {{ generateApplicationUUID "Account2" | quote }}
 		companyName:  "Initech"
 		contactName:  "Bill Lumbergh"
 		emailAddress: "bill.lumbergh@initech.com"
 		phoneNumber:  "(310) 555-5678"
 	}
 	account3: {
-		accountID: {{ generateWorkspaceUUID "Account3" | quote }}
+		accountID: {{ generateApplicationUUID "Account3" | quote }}
 		companyName:  "Vandelay Industries"
 		contactName:  "Art Vandelay"
 		emailAddress: "art.vandelay@vandelay.com"
@@ -121,7 +121,7 @@ let leadMutationList = [
 
 leads: {
 	lead1: {
-		leadID: {{ generateWorkspaceUUID "Lead1" | quote }}
+		leadID: {{ generateApplicationUUID "Lead1" | quote }}
 		companyName:  "Duff Beer"
 		leadSource:   "Trade Show"
 		stage:        "Open"
@@ -131,7 +131,7 @@ leads: {
 		phoneNumber:  "(702) 555-3456"
 	}
 	lead2: {
-		leadID: {{ generateWorkspaceUUID "Lead2" | quote }}
+		leadID: {{ generateApplicationUUID "Lead2" | quote }}
 		companyName:  "Acme Corp"
 		leadSource:   "Referral"
 		stage:        "WIP"
@@ -141,7 +141,7 @@ leads: {
 		phoneNumber:  "(305) 555-7890"
 	}
 	lead3: {
-		leadID: {{ generateWorkspaceUUID "Lead3" | quote }}
+		leadID: {{ generateApplicationUUID "Lead3" | quote }}
 		companyName:  "Bluth Company"
 		leadSource:   "Website"
 		stage:        "Won"
@@ -151,7 +151,7 @@ leads: {
 		phoneNumber:  "(512) 555-1234"
 	}
 	lead4: {
-		leadID: {{ generateWorkspaceUUID "Lead4" | quote }}
+		leadID: {{ generateApplicationUUID "Lead4" | quote }}
 		companyName:  "Wonka Industries"
 		leadSource:   "Email"
 		stage:        "Lost"
@@ -199,28 +199,28 @@ let transactionMutationList = [
 
 transactions: {
 	transaction1: {
-		accountID: {{ generateWorkspaceUUID "Account1" | quote }}
+		accountID: {{ generateApplicationUUID "Account1" | quote }}
 		transactionDate:   "2022-01-25"
 		transactionAmt:    1500
 		transactionType:   "Monthly"
 		transactionMethod: "Credit card"
 	}
 	transaction2: {
-		accountID: {{ generateWorkspaceUUID "Account1" | quote }}
+		accountID: {{ generateApplicationUUID "Account1" | quote }}
 		transactionDate:   "2022-02-25"
 		transactionAmt:    1500
 		transactionType:   "Monthly"
 		transactionMethod: "Credit card"
 	}
 	transaction3: {
-		accountID: {{ generateWorkspaceUUID "Account1" | quote }}
+		accountID: {{ generateApplicationUUID "Account1" | quote }}
 		transactionDate:   "2022-03-25"
 		transactionAmt:    1500
 		transactionType:   "Monthly"
 		transactionMethod: "Credit card"
 	}
 	transaction4: {
-		accountID: {{ generateWorkspaceUUID "Account1" | quote }}
+		accountID: {{ generateApplicationUUID "Account1" | quote }}
 		transactionDate:   "2022-04-25"
 		transactionAmt:    1500
 		transactionType:   "Monthly"

--- a/hris/directory/directory.cue
+++ b/hris/directory/directory.cue
@@ -6,15 +6,15 @@ import (
 
 userTypeMap: {[string]: directoryv1.#UserType} & {
 	Permanent: {
-		id:  {{ generateWorkspaceUUID "PermanentUserType" | quote }}
+		id:  {{ generateApplicationUUID "PermanentUserType" | quote }}
 		name: "Permanent"
 	}
 	Contract: {
-		id: {{ generateWorkspaceUUID "ContractUserType" | quote }}
+		id: {{ generateApplicationUUID "ContractUserType" | quote }}
 		name: "Contract"
 	}
 	Other: {
-		id: {{ generateWorkspaceUUID "OtherUserType" | quote }}
+		id: {{ generateApplicationUUID "OtherUserType" | quote }}
 		name: "Other"
 	}
 }
@@ -27,15 +27,15 @@ userTypeList: [...directoryv1.#UserType] & [
 
 roleClassMap: {[string]: directoryv1.#Role} & {
 	Admin: {
-		id: {{ generateWorkspaceUUID "AdminRoleClass" | quote }}
+		id: {{ generateApplicationUUID "AdminRoleClass" | quote }}
 		name: "Admin"
 	}
 	Staff: {
-		id: {{ generateWorkspaceUUID "StaffRoleClass" | quote }}
+		id: {{ generateApplicationUUID "StaffRoleClass" | quote }}
 		name: "Staff"
 	}
 	Manager: {
-		id: {{ generateWorkspaceUUID "ManagerRoleClass" | quote }}
+		id: {{ generateApplicationUUID "ManagerRoleClass" | quote }}
 		name: "Manager"
 	}
 }
@@ -48,19 +48,19 @@ roleClassList: [...directoryv1.#RoleClass] & [
 
 roleMap: {[string]: directoryv1.#Role} & {
 	Admin: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "AdminRole" | quote }}
+		id: {{ generateApplicationUUID "AdminRole" | quote }}
 		name:        "Admin"
 		roleClassId: roleClassMap.Admin.id
 		policies: [policyList[0].id]
 	}
 	Staff: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "StaffRole" | quote }}
+		id: {{ generateApplicationUUID "StaffRole" | quote }}
 		name:        "Staff"
 		roleClassId: roleClassMap.Staff.id
 		policies: [policyList[1].id]
 	}
 	Manager: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "ManagerRole" | quote }}
+		id: {{ generateApplicationUUID "ManagerRole" | quote }}
 		name:        "Manager"
 		roleClassId: roleClassMap.Manager.id
 		policies: [policyList[1].id]
@@ -69,7 +69,7 @@ roleMap: {[string]: directoryv1.#Role} & {
 
 policyList: [...directoryv1.#Policy] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminPolicy" | quote }}
+		id: {{ generateApplicationUUID "AdminPolicy" | quote }}
 		name:   "admin"
 		permit: "allow"
 		actions: ["*"]
@@ -79,7 +79,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffPolicy" | quote }}
+		id: {{ generateApplicationUUID "StaffPolicy" | quote }}
 		name:   "default"
 		permit: "allow"
 		actions: ["get", "list"]
@@ -89,7 +89,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerPolicy" | quote }}
+		id: {{ generateApplicationUUID "ManagerPolicy" | quote }}
 		name:   "customer"
 		permit: "deny"
 		actions: []
@@ -109,7 +109,7 @@ roleList: [
 
 userList: [...directoryv1.#User] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminUser" | quote }}
+		id: {{ generateApplicationUUID "AdminUser" | quote }}
 		username:    "adminadmin"
 		displayName: "admin"
 		secret:      "adminadmin"
@@ -120,7 +120,7 @@ userList: [...directoryv1.#User] & [
 
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffUser" | quote }}
+		id: {{ generateApplicationUUID "StaffUser" | quote }}
 		username:    "staffstaff"
 		displayName: "staff"
 		secret:      "staffstaff"
@@ -131,7 +131,7 @@ userList: [...directoryv1.#User] & [
 
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerUser" | quote }}
+		id: {{ generateApplicationUUID "ManagerUser" | quote }}
 		username:    "managermanager"
 		displayName: "manager"
 		secret:      "managermanager"

--- a/hris/seed/seed.cue
+++ b/hris/seed/seed.cue
@@ -49,9 +49,9 @@ manifest.#TailorManifest & {
 					}
 				  }"""
 				variables: {
-					id1: {{ generateWorkspaceUUID "Group1" | quote }}
-					id2: {{ generateWorkspaceUUID "Group2" | quote }}
-					id3: {{ generateWorkspaceUUID "Group3" | quote }}
+					id1: {{ generateApplicationUUID "Group1" | quote }}
+					id2: {{ generateApplicationUUID "Group2" | quote }}
+					id3: {{ generateApplicationUUID "Group3" | quote }}
 				}
 			},
 			{
@@ -161,11 +161,11 @@ manifest.#TailorManifest & {
 					}
 				  }"""
 				variables: {
-					userID1:      {{ generateWorkspaceUUID "User1" | quote }}
-					userID2:      {{ generateWorkspaceUUID "User2" | quote }}
-					gid1:        {{ generateWorkspaceUUID "Group1" | quote }}
-					gid2:        {{ generateWorkspaceUUID "Group2" | quote }}
-					gid3:        {{ generateWorkspaceUUID "Group3" | quote }}
+					userID1:      {{ generateApplicationUUID "User1" | quote }}
+					userID2:      {{ generateApplicationUUID "User2" | quote }}
+					gid1:        {{ generateApplicationUUID "Group1" | quote }}
+					gid2:        {{ generateApplicationUUID "Group2" | quote }}
+					gid3:        {{ generateApplicationUUID "Group3" | quote }}
 					permanentID: directories.userTypeMap.Permanent.id
 					contractID:  directories.userTypeMap.Contract.id
 					adminID:     directories.roleMap.Admin.id
@@ -220,8 +220,8 @@ manifest.#TailorManifest & {
 					)
 				  }"""
 				variables: {
-					  userID1: {{ generateWorkspaceUUID "User1" | quote }}
-					  userID2: {{ generateWorkspaceUUID "User2" | quote }}
+					  userID1: {{ generateApplicationUUID "User1" | quote }}
+					  userID2: {{ generateApplicationUUID "User2" | quote }}
 				}
 			},
 		]

--- a/invoice/directory/directory.cue
+++ b/invoice/directory/directory.cue
@@ -6,15 +6,15 @@ import (
 
 userTypeMap: {[string]: directoryv1.#UserType} & {
 	Permanent: {
-		id:  {{ generateWorkspaceUUID "PermanentUserType" | quote }}
+		id:  {{ generateApplicationUUID "PermanentUserType" | quote }}
 		name: "Permanent"
 	}
 	Contract: {
-		id: {{ generateWorkspaceUUID "ContractUserType" | quote }}
+		id: {{ generateApplicationUUID "ContractUserType" | quote }}
 		name: "Contract"
 	}
 	Other: {
-		id: {{ generateWorkspaceUUID "OtherUserType" | quote }}
+		id: {{ generateApplicationUUID "OtherUserType" | quote }}
 		name: "Other"
 	}
 }
@@ -27,19 +27,19 @@ userTypeList: [...directoryv1.#UserType] & [
 
 roleClassMap: {[string]: directoryv1.#Role} & {
 	Admin: {
-		id: {{ generateWorkspaceUUID "AdminRoleClass" | quote }}
+		id: {{ generateApplicationUUID "AdminRoleClass" | quote }}
 		name: "Admin"
 	}
 	Staff: {
-		id: {{ generateWorkspaceUUID "StaffRoleClass" | quote }}
+		id: {{ generateApplicationUUID "StaffRoleClass" | quote }}
 		name: "Staff"
 	}
 	Manager: {
-		id: {{ generateWorkspaceUUID "ManagerRoleClass" | quote }}
+		id: {{ generateApplicationUUID "ManagerRoleClass" | quote }}
 		name: "Manager"
 	}
 	Customer: {
-		id: {{ generateWorkspaceUUID "CustomerRoleClass" | quote }}
+		id: {{ generateApplicationUUID "CustomerRoleClass" | quote }}
 		name: "Customer"
 	}
 }
@@ -53,25 +53,25 @@ roleClassList: [...directoryv1.#RoleClass] & [
 
 roleMap: {[string]: directoryv1.#Role} & {
 	Admin: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "AdminRole" | quote }}
+		id: {{ generateApplicationUUID "AdminRole" | quote }}
 		name:        "Admin"
 		roleClassId: roleClassMap.Admin.id
 		policies: [policyList[0].id]
 	}
 	Staff: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "StaffRole" | quote }}
+		id: {{ generateApplicationUUID "StaffRole" | quote }}
 		name:        "Staff"
 		roleClassId: roleClassMap.Staff.id
 		policies: [policyList[1].id]
 	}
 	Manager: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "ManagerRole" | quote }}
+		id: {{ generateApplicationUUID "ManagerRole" | quote }}
 		name:        "Manager"
 		roleClassId: roleClassMap.Manager.id
 		policies: [policyList[1].id]
 	}
 	Customer: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "CustomerRole" | quote }}
+		id: {{ generateApplicationUUID "CustomerRole" | quote }}
 		name:        "Customer"
 		roleClassId: roleClassMap.Customer.id
 		policies: [policyList[2].id]
@@ -80,7 +80,7 @@ roleMap: {[string]: directoryv1.#Role} & {
 
 policyList: [...directoryv1.#Policy] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminPolicy" | quote }}
+		id: {{ generateApplicationUUID "AdminPolicy" | quote }}
 		name:   "admin"
 		permit: "allow"
 		actions: ["*"]
@@ -90,7 +90,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "DefaultPolicy" | quote }}
+		id: {{ generateApplicationUUID "DefaultPolicy" | quote }}
 		name:   "default"
 		permit: "allow"
 		actions: ["get", "list"]
@@ -100,7 +100,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "CustomerPolicy" | quote }}
+		id: {{ generateApplicationUUID "CustomerPolicy" | quote }}
 		name:   "customer"
 		permit: "deny"
 		actions: []
@@ -120,18 +120,18 @@ roleList: [
 
 groupList: [...directoryv1.#Group] & [
 		{
-		id: {{ generateWorkspaceUUID "InternalGroup" | quote }}
+		id: {{ generateApplicationUUID "InternalGroup" | quote }}
 		name: "internal"
 	},
 	{
-		id: {{ generateWorkspaceUUID "ExternalGroup" | quote }}
+		id: {{ generateApplicationUUID "ExternalGroup" | quote }}
 		name: "external"
 	},
 ]
 
 userList: [...directoryv1.#User] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminUser" | quote }}
+		id: {{ generateApplicationUUID "AdminUser" | quote }}
 		username:    "adminadmin"
 		displayName: "admin"
 		secret:      "adminadmin"
@@ -142,7 +142,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffUser" | quote }}
+		id: {{ generateApplicationUUID "StaffUser" | quote }}
 		username:    "staffstaff"
 		displayName: "staff"
 		secret:      "staffstaff"
@@ -153,7 +153,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerUser" | quote }}
+		id: {{ generateApplicationUUID "ManagerUser" | quote }}
 		username:    "managermanager"
 		displayName: "manager"
 		secret:      "managermanager"
@@ -164,7 +164,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "CustomerUser" | quote }}
+		id: {{ generateApplicationUUID "CustomerUser" | quote }}
 		username:    "customercustomer"
 		displayName: "customer"
 		secret:      "customercustomer"

--- a/invoice/pipeline/resolvers/approveInvoice.cue
+++ b/invoice/pipeline/resolvers/approveInvoice.cue
@@ -42,9 +42,9 @@ approveInvoice: pipelinev1.#Resolver & {
 			description: "change permisssion of the invoice record"
 			url:         settings.services.gateway
 			contextData: json.Marshal({
-				managerRoleID: {{ generateWorkspaceUUID "ManagerRole" | quote }}
-				staffRoleID: {{ generateWorkspaceUUID "StaffRole" | quote }}
-				customerRoleID: {{ generateWorkspaceUUID "CustomerRole" | quote }}
+				managerRoleID: {{ generateApplicationUUID "ManagerRole" | quote }}
+				staffRoleID: {{ generateApplicationUUID "StaffRole" | quote }}
+				customerRoleID: {{ generateApplicationUUID "CustomerRole" | quote }}
 			})
 			test: "!user.roles.exists(e, e == context.data.customerRoleID )"
 			preScript: """

--- a/invoice/pipeline/resolvers/reviewInvoice.cue
+++ b/invoice/pipeline/resolvers/reviewInvoice.cue
@@ -42,7 +42,7 @@ reviewInvoice: pipelinev1.#Resolver & {
 			description: "new state for invoice review"
 			url:         settings.services.gateway
 			contextData: json.Marshal({
-				id:  {{ generateWorkspaceUUID "ReviewFlow1" | quote }}
+				id:  {{ generateApplicationUUID "ReviewFlow1" | quote }}
 			})
 			preScript: """
 				{
@@ -88,8 +88,8 @@ reviewInvoice: pipelinev1.#Resolver & {
 			description: "change permisssion of the invoice record"
 			url:         settings.services.gateway
 			contextData: json.Marshal({
-				managerRoleID: {{ generateWorkspaceUUID "ManagerRole" | quote }}
-				staffRoleID: {{ generateWorkspaceUUID "StaffRole" | quote }}
+				managerRoleID: {{ generateApplicationUUID "ManagerRole" | quote }}
+				staffRoleID: {{ generateApplicationUUID "StaffRole" | quote }}
 			})
 			preScript: """
 				{

--- a/invoice/seed/invoiceReviewFlow.cue
+++ b/invoice/seed/invoiceReviewFlow.cue
@@ -24,7 +24,7 @@ manifest.#TailorManifest & {
 				  }"""
 				variables: {
 					states: invoiceReviewFlow
-					 id: {{ generateWorkspaceUUID "ReviewFlow1" | quote }}
+					 id: {{ generateApplicationUUID "ReviewFlow1" | quote }}
 				}
 			},
 		]
@@ -34,12 +34,12 @@ manifest.#TailorManifest & {
 invoiceReviewFlow: [
 	{
 		name: "ManagerReview"
-		approvers: [{ id: {{ generateWorkspaceUUID "ManagerRole" | quote }} }]
+		approvers: [{ id: {{ generateApplicationUUID "ManagerRole" | quote }} }]
 		transitions: [{action: "approve", destination: "CustomerReview"}]
 	},
 	{
 		name: "CustomerReview"
-		approvers: [{ id: {{ generateWorkspaceUUID "CustomerRole" | quote }} }]
+		approvers: [{ id: {{ generateApplicationUUID "CustomerRole" | quote }} }]
 		transitions: [{action: "approve", destination: "AllApproved"}]
 	},
 	{

--- a/pim/template/directory/directory.cue
+++ b/pim/template/directory/directory.cue
@@ -6,15 +6,15 @@ import (
 
 userTypeMap: {[string]: directoryv1.#UserType} & {
 	Permanent: {
-		id:  {{ generateWorkspaceUUID "PermanentUserType" | quote }}
+		id:  {{ generateApplicationUUID "PermanentUserType" | quote }}
 		name: "Permanent"
 	}
 	Contract: {
-		id: {{ generateWorkspaceUUID "ContractUserType" | quote }}
+		id: {{ generateApplicationUUID "ContractUserType" | quote }}
 		name: "Contract"
 	}
 	Other: {
-		id: {{ generateWorkspaceUUID "OtherUserType" | quote }}
+		id: {{ generateApplicationUUID "OtherUserType" | quote }}
 		name: "Other"
 	}
 }
@@ -27,15 +27,15 @@ userTypeList: [...directoryv1.#UserType] & [
 
 roleClassMap: {[string]: directoryv1.#Role} & {
 	Admin: {
-		id: {{ generateWorkspaceUUID "AdminRoleClass" | quote }}
+		id: {{ generateApplicationUUID "AdminRoleClass" | quote }}
 		name: "Admin"
 	}
 	Staff: {
-		id: {{ generateWorkspaceUUID "StaffRoleClass" | quote }}
+		id: {{ generateApplicationUUID "StaffRoleClass" | quote }}
 		name: "Staff"
 	}
 	Manager: {
-		id: {{ generateWorkspaceUUID "ManagerRoleClass" | quote }}
+		id: {{ generateApplicationUUID "ManagerRoleClass" | quote }}
 		name: "Manager"
 	}
 }
@@ -48,19 +48,19 @@ roleClassList: [...directoryv1.#RoleClass] & [
 
 roleMap: {[string]: directoryv1.#Role} & {
 	Admin: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "AdminRole" | quote }}
+		id: {{ generateApplicationUUID "AdminRole" | quote }}
 		name:        "Admin"
 		roleClassId: roleClassMap.Admin.id
 		policies: [policyList[0].id]
 	}
 	Staff: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "StaffRole" | quote }}
+		id: {{ generateApplicationUUID "StaffRole" | quote }}
 		name:        "Staff"
 		roleClassId: roleClassMap.Staff.id
 		policies: [policyList[1].id]
 	}
 	Manager: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "ManagerRole" | quote }}
+		id: {{ generateApplicationUUID "ManagerRole" | quote }}
 		name:        "Manager"
 		roleClassId: roleClassMap.Manager.id
 		policies: [policyList[1].id]
@@ -69,7 +69,7 @@ roleMap: {[string]: directoryv1.#Role} & {
 
 policyList: [...directoryv1.#Policy] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminPolicy" | quote }}
+		id: {{ generateApplicationUUID "AdminPolicy" | quote }}
 		name:   "admin"
 		permit: "allow"
 		actions: ["*"]
@@ -79,7 +79,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffPolicy" | quote }}
+		id: {{ generateApplicationUUID "StaffPolicy" | quote }}
 		name:   "default"
 		permit: "allow"
 		actions: ["get", "list"]
@@ -89,7 +89,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerPolicy" | quote }}
+		id: {{ generateApplicationUUID "ManagerPolicy" | quote }}
 		name:   "customer"
 		permit: "deny"
 		actions: []
@@ -109,14 +109,14 @@ roleList: [
 
 groupList: [...directoryv1.#Group] & [
 		{
-		id: {{ generateWorkspaceUUID "rootGroup" | quote }}
+		id: {{ generateApplicationUUID "rootGroup" | quote }}
 		name: "rootGroup"
 	},
 ]
 
 userList: [...directoryv1.#User] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminUser" | quote }}
+		id: {{ generateApplicationUUID "AdminUser" | quote }}
 		username:    "adminadmin"
 		displayName: "admin"
 		secret:      "adminadmin"
@@ -127,7 +127,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffUser" | quote }}
+		id: {{ generateApplicationUUID "StaffUser" | quote }}
 		username:    "staffstaff"
 		displayName: "staff"
 		secret:      "staffstaff"
@@ -138,7 +138,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerUser" | quote }}
+		id: {{ generateApplicationUUID "ManagerUser" | quote }}
 		username:    "managermanager"
 		displayName: "manager"
 		secret:      "managermanager"

--- a/pim/template/seed/seed.cue
+++ b/pim/template/seed/seed.cue
@@ -34,12 +34,12 @@ let mutationList = [
 
 brands: {
 	brand1: {
-		id:    {{ generateWorkspaceUUID "brandA" | quote }}
+		id:    {{ generateApplicationUUID "brandA" | quote }}
 		name:     "BrandA"
 		description: "Brand A"
 	}
 	brand2: {
-		id:    {{ generateWorkspaceUUID "brandB" | quote }}
+		id:    {{ generateApplicationUUID "brandB" | quote }}
 		name:     "BrandB"
 		description: "Brand B"
 	}

--- a/scm_adv/directory/directory.cue
+++ b/scm_adv/directory/directory.cue
@@ -6,15 +6,15 @@ import (
 
 userTypeMap: {[string]: directoryv1.#UserType} & {
 	Permanent: {
-		id:  {{ generateWorkspaceUUID "PermanentUserType" | quote }}
+		id:  {{ generateApplicationUUID "PermanentUserType" | quote }}
 		name: "Permanent"
 	}
 	Contract: {
-		id: {{ generateWorkspaceUUID "ContractUserType" | quote }}
+		id: {{ generateApplicationUUID "ContractUserType" | quote }}
 		name: "Contract"
 	}
 	Other: {
-		id: {{ generateWorkspaceUUID "OtherUserType" | quote }}
+		id: {{ generateApplicationUUID "OtherUserType" | quote }}
 		name: "Other"
 	}
 }
@@ -27,15 +27,15 @@ userTypeList: [...directoryv1.#UserType] & [
 
 roleClassMap: {[string]: directoryv1.#Role} & {
 	Admin: {
-		id: {{ generateWorkspaceUUID "AdminRoleClass" | quote }}
+		id: {{ generateApplicationUUID "AdminRoleClass" | quote }}
 		name: "Admin"
 	}
 	Staff: {
-		id: {{ generateWorkspaceUUID "StaffRoleClass" | quote }}
+		id: {{ generateApplicationUUID "StaffRoleClass" | quote }}
 		name: "Staff"
 	}
 	Manager: {
-		id: {{ generateWorkspaceUUID "ManagerRoleClass" | quote }}
+		id: {{ generateApplicationUUID "ManagerRoleClass" | quote }}
 		name: "Manager"
 	}
 }
@@ -48,19 +48,19 @@ roleClassList: [...directoryv1.#RoleClass] & [
 
 roleMap: {[string]: directoryv1.#Role} & {
 	Admin: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "AdminRole" | quote }}
+		id: {{ generateApplicationUUID "AdminRole" | quote }}
 		name:        "Admin"
 		roleClassId: roleClassMap.Admin.id
 		policies: [policyList[0].id]
 	}
 	Staff: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "StaffRole" | quote }}
+		id: {{ generateApplicationUUID "StaffRole" | quote }}
 		name:        "Staff"
 		roleClassId: roleClassMap.Staff.id
 		policies: [policyList[1].id]
 	}
 	Manager: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "ManagerRole" | quote }}
+		id: {{ generateApplicationUUID "ManagerRole" | quote }}
 		name:        "Manager"
 		roleClassId: roleClassMap.Manager.id
 		policies: [policyList[1].id]
@@ -69,7 +69,7 @@ roleMap: {[string]: directoryv1.#Role} & {
 
 policyList: [...directoryv1.#Policy] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminPolicy" | quote }}
+		id: {{ generateApplicationUUID "AdminPolicy" | quote }}
 		name:   "admin"
 		permit: "allow"
 		actions: ["*"]
@@ -79,7 +79,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffPolicy" | quote }}
+		id: {{ generateApplicationUUID "StaffPolicy" | quote }}
 		name:   "default"
 		permit: "allow"
 		actions: ["get", "list"]
@@ -89,7 +89,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerPolicy" | quote }}
+		id: {{ generateApplicationUUID "ManagerPolicy" | quote }}
 		name:   "customer"
 		permit: "deny"
 		actions: []
@@ -109,18 +109,18 @@ roleList: [
 
 groupList: [...directoryv1.#Group] & [
 		{
-		id: {{ generateWorkspaceUUID "InternalGroup" | quote }}
+		id: {{ generateApplicationUUID "InternalGroup" | quote }}
 		name: "internal"
 	},
 	{
-		id: {{ generateWorkspaceUUID "ExternalGroup" | quote }}
+		id: {{ generateApplicationUUID "ExternalGroup" | quote }}
 		name: "external"
 	},
 ]
 
 userList: [...directoryv1.#User] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminUser" | quote }}
+		id: {{ generateApplicationUUID "AdminUser" | quote }}
 		username:    "adminadmin"
 		displayName: "admin"
 		secret:      "adminadmin"
@@ -131,7 +131,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffUser" | quote }}
+		id: {{ generateApplicationUUID "StaffUser" | quote }}
 		username:    "staffstaff"
 		displayName: "staff"
 		secret:      "staffstaff"
@@ -142,7 +142,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerUser" | quote }}
+		id: {{ generateApplicationUUID "ManagerUser" | quote }}
 		username:    "managermanager"
 		displayName: "manager"
 		secret:      "managermanager"

--- a/scm_adv/seed/location.cue
+++ b/scm_adv/seed/location.cue
@@ -57,7 +57,7 @@ let mutationList = [
 
 locations: {
 	location1: {
-		id:    {{ generateWorkspaceUUID "Location1" | quote }}
+		id:    {{ generateApplicationUUID "Location1" | quote }}
 		code:     1
 		name:     "Globex Corporation"
 		country:  "USA"
@@ -67,7 +67,7 @@ locations: {
 		zipcode:  "10006"
 	}
 	location2: {
-		id:   {{ generateWorkspaceUUID "Location2" | quote }}
+		id:   {{ generateApplicationUUID "Location2" | quote }}
 		code:     2
 		name:     "Soylent Corp"
 		country:  "USA"
@@ -77,7 +77,7 @@ locations: {
 		zipcode:  "90028"
 	}
 	location3: {
-		id:   {{ generateWorkspaceUUID "Location3" | quote }}
+		id:   {{ generateApplicationUUID "Location3" | quote }}
 		code:     3
 		name:     "Initech"
 		country:  "USA"

--- a/scm_adv/seed/order.cue
+++ b/scm_adv/seed/order.cue
@@ -48,15 +48,15 @@ orders: {
 	order1: {
 		quantity:   2
 		placedDate: "2023-01-01"
-		productID:  {{ generateWorkspaceUUID "Product1" | quote }}
-		locationID: {{ generateWorkspaceUUID "Location1" | quote }}
+		productID:  {{ generateApplicationUUID "Product1" | quote }}
+		locationID: {{ generateApplicationUUID "Location1" | quote }}
 	}
 
 	order2: {
 		quantity:   3
 		placedDate: "2023-01-02"
-		productID: {{ generateWorkspaceUUID "Product2" | quote }}
-		locationID: {{ generateWorkspaceUUID "Location2" | quote }}
+		productID: {{ generateApplicationUUID "Product2" | quote }}
+		locationID: {{ generateApplicationUUID "Location2" | quote }}
 	}
 
 }

--- a/scm_adv/seed/product.cue
+++ b/scm_adv/seed/product.cue
@@ -54,7 +54,7 @@ let mutationList = [
 
 products: {
 	product1: {
-		id:       {{ generateWorkspaceUUID "Product1" | quote }}
+		id:       {{ generateApplicationUUID "Product1" | quote }}
 		ppu:      12.99
 		ean:      "5012345678910"
 		uom:      "pack"
@@ -63,7 +63,7 @@ products: {
 		code:     1
 	}
 	product2: {
-		id:      {{ generateWorkspaceUUID "Product2" | quote }}
+		id:      {{ generateApplicationUUID "Product2" | quote }}
 		ppu:      24.99
 		ean:      "6012345678911"
 		uom:      "box"
@@ -72,7 +72,7 @@ products: {
 		code:     2
 	}
 	product3: {
-		id:       {{ generateWorkspaceUUID "Product3" | quote }}
+		id:       {{ generateApplicationUUID "Product3" | quote }}
 		ppu:      45.00
 		ean:      "7012345678912"
 		uom:      "piece"
@@ -81,7 +81,7 @@ products: {
 		code:     3
 	}
 	product4: {
-		id:       {{ generateWorkspaceUUID "Product4" | quote }}
+		id:       {{ generateApplicationUUID "Product4" | quote }}
 		ppu:      8.50
 		ean:      "8012345678913"
 		uom:      "pack"
@@ -90,7 +90,7 @@ products: {
 		code:     4
 	}
 	product5: {
-		id:       {{ generateWorkspaceUUID "Product5" | quote }}
+		id:       {{ generateApplicationUUID "Product5" | quote }}
 		ppu:      14.75
 		ean:      "9012345678914"
 		uom:      "set"

--- a/scm_adv/seed/purchase.cue
+++ b/scm_adv/seed/purchase.cue
@@ -47,15 +47,15 @@ purchases: {
 	order1: {
 		quantity:   15
 		placedDate: "2023-01-01"
-		productID:  {{ generateWorkspaceUUID "Product1" | quote }}
-		locationID: {{ generateWorkspaceUUID "Location1" | quote }}
+		productID:  {{ generateApplicationUUID "Product1" | quote }}
+		locationID: {{ generateApplicationUUID "Location1" | quote }}
 	}
 
 	order2: {
 		quantity:   8
 		placedDate: "2023-01-02"
-		productID:  {{ generateWorkspaceUUID "Product2" | quote }}
-		locationID: {{ generateWorkspaceUUID "Location2" | quote }}
+		productID:  {{ generateApplicationUUID "Product2" | quote }}
+		locationID: {{ generateApplicationUUID "Location2" | quote }}
 	}
 
 }

--- a/scm_simplified/directory/directory.cue
+++ b/scm_simplified/directory/directory.cue
@@ -6,15 +6,15 @@ import (
 
 userTypeMap: {[string]: directoryv1.#UserType} & {
 	Permanent: {
-		id:  {{ generateWorkspaceUUID "PermanentUserType" | quote }}
+		id:  {{ generateApplicationUUID "PermanentUserType" | quote }}
 		name: "Permanent"
 	}
 	Contract: {
-		id: {{ generateWorkspaceUUID "ContractUserType" | quote }}
+		id: {{ generateApplicationUUID "ContractUserType" | quote }}
 		name: "Contract"
 	}
 	Other: {
-		id: {{ generateWorkspaceUUID "OtherUserType" | quote }}
+		id: {{ generateApplicationUUID "OtherUserType" | quote }}
 		name: "Other"
 	}
 }
@@ -27,15 +27,15 @@ userTypeList: [...directoryv1.#UserType] & [
 
 roleClassMap: {[string]: directoryv1.#Role} & {
 	Admin: {
-		id: {{ generateWorkspaceUUID "AdminRoleClass" | quote }}
+		id: {{ generateApplicationUUID "AdminRoleClass" | quote }}
 		name: "Admin"
 	}
 	Staff: {
-		id: {{ generateWorkspaceUUID "StaffRoleClass" | quote }}
+		id: {{ generateApplicationUUID "StaffRoleClass" | quote }}
 		name: "Staff"
 	}
 	Manager: {
-		id: {{ generateWorkspaceUUID "ManagerRoleClass" | quote }}
+		id: {{ generateApplicationUUID "ManagerRoleClass" | quote }}
 		name: "Manager"
 	}
 }
@@ -48,19 +48,19 @@ roleClassList: [...directoryv1.#RoleClass] & [
 
 roleMap: {[string]: directoryv1.#Role} & {
 	Admin: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "AdminRole" | quote }}
+		id: {{ generateApplicationUUID "AdminRole" | quote }}
 		name:        "Admin"
 		roleClassId: roleClassMap.Admin.id
 		policies: [policyList[0].id]
 	}
 	Staff: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "StaffRole" | quote }}
+		id: {{ generateApplicationUUID "StaffRole" | quote }}
 		name:        "Staff"
 		roleClassId: roleClassMap.Staff.id
 		policies: [policyList[1].id]
 	}
 	Manager: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "ManagerRole" | quote }}
+		id: {{ generateApplicationUUID "ManagerRole" | quote }}
 		name:        "Manager"
 		roleClassId: roleClassMap.Manager.id
 		policies: [policyList[1].id]
@@ -69,7 +69,7 @@ roleMap: {[string]: directoryv1.#Role} & {
 
 policyList: [...directoryv1.#Policy] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminPolicy" | quote }}
+		id: {{ generateApplicationUUID "AdminPolicy" | quote }}
 		name:   "admin"
 		permit: "allow"
 		actions: ["*"]
@@ -79,7 +79,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffPolicy" | quote }}
+		id: {{ generateApplicationUUID "StaffPolicy" | quote }}
 		name:   "default"
 		permit: "allow"
 		actions: ["get", "list"]
@@ -89,7 +89,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerPolicy" | quote }}
+		id: {{ generateApplicationUUID "ManagerPolicy" | quote }}
 		name:   "customer"
 		permit: "deny"
 		actions: []
@@ -109,18 +109,18 @@ roleList: [
 
 groupList: [...directoryv1.#Group] & [
 		{
-		id: {{ generateWorkspaceUUID "InternalGroup" | quote }}
+		id: {{ generateApplicationUUID "InternalGroup" | quote }}
 		name: "internal"
 	},
 	{
-		id: {{ generateWorkspaceUUID "ExternalGroup" | quote }}
+		id: {{ generateApplicationUUID "ExternalGroup" | quote }}
 		name: "external"
 	},
 ]
 
 userList: [...directoryv1.#User] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminUser" | quote }}
+		id: {{ generateApplicationUUID "AdminUser" | quote }}
 		username:    "adminadmin"
 		displayName: "admin"
 		secret:      "adminadmin"
@@ -131,7 +131,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffUser" | quote }}
+		id: {{ generateApplicationUUID "StaffUser" | quote }}
 		username:    "staffstaff"
 		displayName: "staff"
 		secret:      "staffstaff"
@@ -142,7 +142,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerUser" | quote }}
+		id: {{ generateApplicationUUID "ManagerUser" | quote }}
 		username:    "managermanager"
 		displayName: "manager"
 		secret:      "managermanager"

--- a/scm_simplified/seed/location.cue
+++ b/scm_simplified/seed/location.cue
@@ -57,7 +57,7 @@ let mutationList = [
 
 locations: {
 	location1: {
-		id:    {{ generateWorkspaceUUID "Location1" | quote }}
+		id:    {{ generateApplicationUUID "Location1" | quote }}
 		code:     1
 		name:     "Vandelay Industries"
 		country:  "USA"
@@ -67,7 +67,7 @@ locations: {
 		zipcode:  "10024"
 	}
 	location2: {
-		id:   {{ generateWorkspaceUUID "Location2" | quote }}
+		id:   {{ generateApplicationUUID "Location2" | quote }}
 		code:     2
 		name:     "Satriale's Pork Store"
 		country:  "USA"
@@ -77,7 +77,7 @@ locations: {
 		zipcode:  "07032"
 	}
 	location3: {
-		id:   {{ generateWorkspaceUUID "Location3" | quote }}
+		id:   {{ generateApplicationUUID "Location3" | quote }}
 		code:     3
 		name:     "Los Pollos Hermanos"
 		country:  "USA"

--- a/scm_simplified/seed/product.cue
+++ b/scm_simplified/seed/product.cue
@@ -54,7 +54,7 @@ let mutationList = [
 
 products: {
 	product1: {
-		id:    {{ generateWorkspaceUUID "Product1" | quote }}
+		id:    {{ generateApplicationUUID "Product1" | quote }}
 		ppu:      15.99
 		ean:      "5012345678910"
 		uom:      "pack"
@@ -63,7 +63,7 @@ products: {
 		code:     1
 	}
 	product2: {
-		id:   {{ generateWorkspaceUUID "Product2" | quote }}
+		id:   {{ generateApplicationUUID "Product2" | quote }}
 		ppu:      30.99
 		ean:      "6012345678911"
 		uom:      "box"
@@ -72,7 +72,7 @@ products: {
 		code:     2
 	}
 	product3: {
-		id:   {{ generateWorkspaceUUID "Product3" | quote }}
+		id:   {{ generateApplicationUUID "Product3" | quote }}
 		ppu:      55.00
 		ean:      "7012345678912"
 		uom:      "piece"
@@ -81,7 +81,7 @@ products: {
 		code:     3
 	}
 	product4: {
-		id:   {{ generateWorkspaceUUID "Product4" | quote }}
+		id:   {{ generateApplicationUUID "Product4" | quote }}
 		ppu:      10.50
 		ean:      "8012345678913"
 		uom:      "pack"
@@ -90,7 +90,7 @@ products: {
 		code:     4
 	}
 	product5: {
-		id:   {{ generateWorkspaceUUID "Product5" | quote }}
+		id:   {{ generateApplicationUUID "Product5" | quote }}
 		ppu:      18.75
 		ean:      "9012345678914"
 		uom:      "set"

--- a/tutorial/todo-app-pipelines/directory/directory.cue
+++ b/tutorial/todo-app-pipelines/directory/directory.cue
@@ -6,15 +6,15 @@ import (
 
 roleClassMap: {[string]: directoryv1.#Role} & {
 	Admin: {
-		id: {{ generateWorkspaceUUID "AdminRoleClass" | quote }}
+		id: {{ generateApplicationUUID "AdminRoleClass" | quote }}
 		name: "Admin"
 	}
 	Staff: {
-		id: {{ generateWorkspaceUUID "StaffRoleClass" | quote }}
+		id: {{ generateApplicationUUID "StaffRoleClass" | quote }}
 		name: "Staff"
 	}
 	Manager: {
-		id: {{ generateWorkspaceUUID "ManagerRoleClass" | quote }}
+		id: {{ generateApplicationUUID "ManagerRoleClass" | quote }}
 		name: "Manager"
 	}
 }
@@ -27,19 +27,19 @@ roleClassList: [...directoryv1.#RoleClass] & [
 
 roleMap: {[string]: directoryv1.#Role} & {
 	Admin: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "AdminRole" | quote }}
+		id: {{ generateApplicationUUID "AdminRole" | quote }}
 		name:        "Admin"
 		roleClassId: roleClassMap.Admin.id
 		policies: [policyList[0].id]
 	}
 	Staff: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "StaffRole" | quote }}
+		id: {{ generateApplicationUUID "StaffRole" | quote }}
 		name:        "Staff"
 		roleClassId: roleClassMap.Staff.id
 		policies: [policyList[1].id]
 	}
 	Manager: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "ManagerRole" | quote }}
+		id: {{ generateApplicationUUID "ManagerRole" | quote }}
 		name:        "Manager"
 		roleClassId: roleClassMap.Manager.id
 		policies: [policyList[1].id]
@@ -48,7 +48,7 @@ roleMap: {[string]: directoryv1.#Role} & {
 
 policyList: [...directoryv1.#Policy] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminPolicy" | quote }}
+		id: {{ generateApplicationUUID "AdminPolicy" | quote }}
 		name:   "admin"
 		permit: "allow"
 		actions: ["*"]
@@ -58,7 +58,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffPolicy" | quote }}
+		id: {{ generateApplicationUUID "StaffPolicy" | quote }}
 		name:   "default"
 		permit: "allow"
 		actions: ["get", "list"]
@@ -68,7 +68,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerPolicy" | quote }}
+		id: {{ generateApplicationUUID "ManagerPolicy" | quote }}
 		name:   "customer"
 		permit: "deny"
 		actions: []
@@ -88,18 +88,18 @@ roleList: [
 
 groupList: [...directoryv1.#Group] & [
 		{
-		id: {{ generateWorkspaceUUID "InternalGroup" | quote }}
+		id: {{ generateApplicationUUID "InternalGroup" | quote }}
 		name: "internal"
 	},
 	{
-		id: {{ generateWorkspaceUUID "ExternalGroup" | quote }}
+		id: {{ generateApplicationUUID "ExternalGroup" | quote }}
 		name: "external"
 	},
 ]
 
 userList: [...directoryv1.#User] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminUser" | quote }}
+		id: {{ generateApplicationUUID "AdminUser" | quote }}
 		username:    "adminadmin"
 		displayName: "admin"
 		secret:      "adminadmin"
@@ -107,7 +107,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffUser" | quote }}
+		id: {{ generateApplicationUUID "StaffUser" | quote }}
 		username:    "staffstaff"
 		displayName: "staff"
 		secret:      "staffstaff"
@@ -115,7 +115,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerUser" | quote }}
+		id: {{ generateApplicationUUID "ManagerUser" | quote }}
 		username:    "managermanager"
 		displayName: "manager"
 		secret:      "managermanager"

--- a/tutorial/todo-app-stateflow/directory/directory.cue
+++ b/tutorial/todo-app-stateflow/directory/directory.cue
@@ -6,15 +6,15 @@ import (
 
 roleClassMap: {[string]: directoryv1.#Role} & {
 	Admin: {
-		id: {{ generateWorkspaceUUID "AdminRoleClass" | quote }}
+		id: {{ generateApplicationUUID "AdminRoleClass" | quote }}
 		name: "Admin"
 	}
 	Staff: {
-		id: {{ generateWorkspaceUUID "StaffRoleClass" | quote }}
+		id: {{ generateApplicationUUID "StaffRoleClass" | quote }}
 		name: "Staff"
 	}
 	Manager: {
-		id: {{ generateWorkspaceUUID "ManagerRoleClass" | quote }}
+		id: {{ generateApplicationUUID "ManagerRoleClass" | quote }}
 		name: "Manager"
 	}
 }
@@ -27,19 +27,19 @@ roleClassList: [...directoryv1.#RoleClass] & [
 
 roleMap: {[string]: directoryv1.#Role} & {
 	Admin: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "AdminRole" | quote }}
+		id: {{ generateApplicationUUID "AdminRole" | quote }}
 		name:        "Admin"
 		roleClassId: roleClassMap.Admin.id
 		policies: [policyList[0].id]
 	}
 	Staff: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "StaffRole" | quote }}
+		id: {{ generateApplicationUUID "StaffRole" | quote }}
 		name:        "Staff"
 		roleClassId: roleClassMap.Staff.id
 		policies: [policyList[1].id]
 	}
 	Manager: directoryv1.#Role & {
-		id: {{ generateWorkspaceUUID "ManagerRole" | quote }}
+		id: {{ generateApplicationUUID "ManagerRole" | quote }}
 		name:        "Manager"
 		roleClassId: roleClassMap.Manager.id
 		policies: [policyList[1].id]
@@ -48,7 +48,7 @@ roleMap: {[string]: directoryv1.#Role} & {
 
 policyList: [...directoryv1.#Policy] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminPolicy" | quote }}
+		id: {{ generateApplicationUUID "AdminPolicy" | quote }}
 		name:   "admin"
 		permit: "allow"
 		actions: ["*"]
@@ -58,7 +58,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffPolicy" | quote }}
+		id: {{ generateApplicationUUID "StaffPolicy" | quote }}
 		name:   "default"
 		permit: "allow"
 		actions: ["get", "list"]
@@ -68,7 +68,7 @@ policyList: [...directoryv1.#Policy] & [
 		passwordRule: 4
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerPolicy" | quote }}
+		id: {{ generateApplicationUUID "ManagerPolicy" | quote }}
 		name:   "customer"
 		permit: "deny"
 		actions: []
@@ -88,18 +88,18 @@ roleList: [
 
 groupList: [...directoryv1.#Group] & [
 		{
-		id: {{ generateWorkspaceUUID "InternalGroup" | quote }}
+		id: {{ generateApplicationUUID "InternalGroup" | quote }}
 		name: "internal"
 	},
 	{
-		id: {{ generateWorkspaceUUID "ExternalGroup" | quote }}
+		id: {{ generateApplicationUUID "ExternalGroup" | quote }}
 		name: "external"
 	},
 ]
 
 userList: [...directoryv1.#User] & [
 		{
-		id: {{ generateWorkspaceUUID "AdminUser" | quote }}
+		id: {{ generateApplicationUUID "AdminUser" | quote }}
 		username:    "adminadmin"
 		displayName: "admin"
 		secret:      "adminadmin"
@@ -107,7 +107,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "StaffUser" | quote }}
+		id: {{ generateApplicationUUID "StaffUser" | quote }}
 		username:    "staffstaff"
 		displayName: "staff"
 		secret:      "staffstaff"
@@ -115,7 +115,7 @@ userList: [...directoryv1.#User] & [
 		groups: [groupList[0].id]
 	},
 	{
-		id: {{ generateWorkspaceUUID "ManagerUser" | quote }}
+		id: {{ generateApplicationUUID "ManagerUser" | quote }}
 		username:    "managermanager"
 		displayName: "manager"
 		secret:      "managermanager"


### PR DESCRIPTION
Currently the templates use generateWorkspaceUUID.
In this case, we can't deploy multiple templates in the single workspace as it causes UUID duplication.

This PR to fix the issue by using generateApplicationUUID