### PR TITLE
fix: update to no longer expect array from

### DIFF
--- a/common/scripts/seed.mjs
+++ b/common/scripts/seed.mjs
@@ -53,19 +53,19 @@ async function configureEnvironment() {
 		}
 	} while (!workspace);
 
-	if (workspace[0].name) {
+	if (workspace.name) {
 		if (!skipPrompts) {
 			const continuePrompt = await prompts({
 				type: "confirm",
 				name: "value",
-				message: `Do you want to use the workspace ${workspace[0].name}?`,
+				message: `Do you want to use the workspace ${workspace.name}?`,
 				initial: true,
 			});
 			if (!continuePrompt.value) {
 				await selectWorkspace();
 			}
 		} else {
-			selectedWorkspace = workspace[0]; // Auto-select the first workspace
+			selectedWorkspace = workspace; // Auto-select the first workspace
 		}
 	}
 	const appsJsonString = await $$({

--- a/omakase/seed.mjs
+++ b/omakase/seed.mjs
@@ -53,19 +53,19 @@ async function configureEnvironment() {
 		}
 	} while (!workspace);
 
-	if (workspace[0].name) {
+	if (workspace.name) {
 		if (!skipPrompts) {
 			const continuePrompt = await prompts({
 				type: "confirm",
 				name: "value",
-				message: `Do you want to use the workspace ${workspace[0].name}?`,
+				message: `Do you want to use the workspace ${workspace.name}?`,
 				initial: true,
 			});
 			if (!continuePrompt.value) {
 				await selectWorkspace();
 			}
 		} else {
-			selectedWorkspace = workspace[0]; // Auto-select the first workspace
+			selectedWorkspace = workspace; // Auto-select the first workspace
 		}
 	}
 	const appsJsonString = await $$({

--- a/omakase/seed_demo.mjs
+++ b/omakase/seed_demo.mjs
@@ -53,19 +53,19 @@ async function configureEnvironment() {
 		}
 	} while (!workspace);
 
-	if (workspace[0].name) {
+	if (workspace.name) {
 		if (!skipPrompts) {
 			const continuePrompt = await prompts({
 				type: "confirm",
 				name: "value",
-				message: `Do you want to use the workspace ${workspace[0].name}?`,
+				message: `Do you want to use the workspace ${workspace.name}?`,
 				initial: true,
 			});
 			if (!continuePrompt.value) {
 				await selectWorkspace();
 			}
 		} else {
-			selectedWorkspace = workspace[0]; // Auto-select the first workspace
+			selectedWorkspace = workspace; // Auto-select the first workspace
 		}
 	}
 	const appsJsonString = await $$({

--- a/omakase/seed_more.mjs
+++ b/omakase/seed_more.mjs
@@ -51,21 +51,21 @@ async function configureEnvironment() {
     }
   } while (!workspace);
 
-  if (workspace[0].name) {
+  if (workspace.name) {
     if (!skipPrompts) {
       const continuePrompt = await prompts({
         type: "confirm",
         name: "value",
-        message: `Do you want to use the workspace ${workspace[0].name}?`,
+        message: `Do you want to use the workspace ${workspace.name}?`,
         initial: true,
       });
       if (!continuePrompt.value) {
         await selectWorkspace();
       } else {
-        selectedWorkspace = workspace[0];
+        selectedWorkspace = workspace;
       }
     } else {
-      selectedWorkspace = workspace[0]; // Auto-select the first workspace
+      selectedWorkspace = workspace; // Auto-select the first workspace
     }
   }
   const appsJsonString = await $$({


### PR DESCRIPTION
The command `tailorctl workspace describe -f json` had previously been returning an array of the workspace, and the data was selected with `workspace[0].name` and `workspace[0]`.  

This PR updates the code to no longer look in the first array element, and instead look at `workspace.name` to check for name and `workspace` to assign the selected workspace