### PR TITLE
Add example of tailor.iconv 

### DIFF
--- a/examples/iconv/README.md
+++ b/examples/iconv/README.md
@@ -1,0 +1,99 @@
+# Tailor Platform iconv Examples
+
+This directory contains comprehensive examples of using the `tailor.iconv` APIs in Tailor Platform Functions.
+
+## Overview
+
+The iconv API provides character encoding conversion capabilities, allowing you to:
+- Encode strings to different character encodings
+- Decode byte arrays back to strings
+- Convert between various character encodings
+- Check encoding availability
+- Handle encoding errors gracefully
+
+## Examples Included
+
+### Basic Operations
+- **encode/decode**: Convert strings to/from UTF-8 encoded byte arrays
+- **Japanese text handling**: Encode and decode Japanese characters
+
+### Encoding Conversions
+- **UTF-8 ↔ Shift_JIS**: Common Japanese encoding conversion
+- **UTF-8 → HitachiKEIS90**: Special mainframe encoding with //IGNORE flag
+- **UTF-8 → ISO-2022-JP**: Email-safe Japanese encoding
+- **UTF-8 ↔ EUC-JP**: Unix-based Japanese encoding
+- **UTF-8 ↔ UTF-16**: Unicode transformation format conversion
+- **UTF-8 → ASCII**: With //IGNORE and //TRANSLIT flags for error handling
+
+### Encoding Availability
+- Check if specific encodings are available
+- List all available encodings
+- Verify support for:
+  - EBCDIC-JP-E
+  - EBCDIC-JP-KANA
+  - IBM290
+  - IBM930
+  - And many more
+
+## Setup
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the function
+pnpm build
+```
+
+## API Reference
+
+### `tailor.iconv.encode(text: string, encoding: string): Uint8Array`
+Encodes a string into a byte array using the specified encoding.
+
+### `tailor.iconv.decode(bytes: Uint8Array, encoding: string): string`
+Decodes a byte array back to a string using the specified encoding.
+
+### `tailor.iconv.convert(data: string | Uint8Array, fromEncoding: string, toEncoding: string): string | Uint8Array`
+Converts data from one encoding to another.
+
+### `tailor.iconv.getEncodingList(): string[]`
+Returns a list of all available encodings.
+
+## Error Handling Flags
+
+- **//IGNORE**: Silently ignores characters that cannot be converted
+- **//TRANSLIT**: Attempts to transliterate characters to similar ones in target encoding
+- **Custom Replacement Characters (Extension)**: `//TRANSLIT:char` allows specifying custom replacement characters
+  - Default: `//TRANSLIT` replaces unconvertible characters with `?`
+  - Example: `ASCII//TRANSLIT:*` replaces unconvertible characters with `*`
+  - Example: `ASCII//TRANSLIT:[?]` replaces unconvertible characters with `[?]`
+
+## Usage Example
+
+```javascript
+// Basic encode/decode
+const testString = "Hello, World!";
+const encoded = tailor.iconv.encode(testString, "UTF-8");
+const decoded = tailor.iconv.decode(encoded, "UTF-8");
+
+// Special encoding conversion
+const testString = "HELLO(コンニチハ)";
+const encoded = tailor.iconv.convert(testString, "UTF-8", "HitachiKEIS90//IGNORE");
+// Result: Byte array without unconvertible characters
+
+// Transliteration example
+const testString = "HELLOこんにちは";
+const encoded = tailor.iconv.convert(testString, "UTF-8", "ASCII//TRANSLIT:*");
+// Result: "HELLO*****"
+
+// Check encoding availability
+const encodingList = tailor.iconv.getEncodingList();
+const hasEBCDICJPE = encodingList.includes("EBCDIC-JP-E");
+```
+
+## Notes
+
+- The function returns a comprehensive results object showing all conversion examples
+- Error handling is implemented for each conversion attempt
+- Byte arrays are returned as arrays in the results for visibility
+- The //IGNORE and //TRANSLIT flags help handle characters that don't exist in target encodings

--- a/examples/iconv/build.mjs
+++ b/examples/iconv/build.mjs
@@ -1,0 +1,11 @@
+import * as esbuild from 'esbuild';
+
+await esbuild.build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  minify: true,
+  platform: 'neutral',
+  outfile: 'dist/index.js',
+  format: 'esm',
+  target: 'es2020',
+});

--- a/examples/iconv/package.json
+++ b/examples/iconv/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tailor-iconv-example",
+  "description": "Examples of using tailor.iconv APIs in the Function service",
+  "scripts": {
+    "build": "node ./build.mjs"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@tailor-platform/function-types": "^0.4.0",
+    "@tsconfig/recommended": "^1.0.8",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.7.3"
+  },
+  "packageManager": "pnpm@10.2.1"
+}

--- a/examples/iconv/pnpm-lock.yaml
+++ b/examples/iconv/pnpm-lock.yaml
@@ -1,0 +1,311 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@tailor-platform/function-types':
+        specifier: ^0.4.0
+        version: 0.4.0
+      '@tsconfig/recommended':
+        specifier: ^1.0.8
+        version: 1.0.10
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.9
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.2
+
+packages:
+
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailor-platform/function-types@0.4.0':
+    resolution: {integrity: sha512-K7D3Mx+vvzw/wxcRFhnBwpN6t1tyV60LkSbQYNkBx9NJRy8NN/h/4ghmFOj4eLkSQ/dwuEqzf+n8F3iAyE9Mkw==}
+
+  '@tsconfig/recommended@1.0.10':
+    resolution: {integrity: sha512-cGvydvg03lONp5Z9yaplW493Vw9/um7k588mvDkm+VFPF2PZUVPx0uswq4PFpeEySsLbQRETrDRhzh4Dmxaslw==}
+
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
+    optional: true
+
+  '@tailor-platform/function-types@0.4.0': {}
+
+  '@tsconfig/recommended@1.0.10': {}
+
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
+
+  typescript@5.9.2: {}

--- a/examples/iconv/src/index.ts
+++ b/examples/iconv/src/index.ts
@@ -1,0 +1,211 @@
+export default async () => {
+  console.log("Starting iconv examples");
+  
+  const results: Record<string, any> = {};
+
+  try {
+    console.log("=== Basic Encode/Decode Example ===");
+    const testString = "Hello, 世界! こんにちは";
+    const encoded = tailor.iconv.encode(testString,"SHIFT-JIS");
+    console.log(`Encoded "${testString}" to UTF-8:`, encoded);
+    results.basicEncode = { input: testString, encoded: Array.from(encoded) };
+
+    const decoded = tailor.iconv.decode(encoded, "SHIFT-JIS");
+    console.log(`Decoded back to string: "${decoded}"`);
+    results.basicDecode = { encoded: Array.from(encoded), decoded };
+
+  } catch (error) {
+    console.error("Error in basic encode/decode:", error);
+    results.basicError = error;
+  }
+
+  try {
+    console.log("\n=== Japanese Text Encode/Decode ===");
+    const japaneseText = "こんにちは世界";
+    const japaneseEncoded = tailor.iconv.encode(japaneseText, "SHIFT-JIS");
+    console.log(`Encoded Japanese "${japaneseText}":`, japaneseEncoded);
+    results.japaneseEncode = { input: japaneseText, encoded: Array.from(japaneseEncoded) };
+
+    const japaneseDecoded = tailor.iconv.decode(japaneseEncoded, "SHIFT-JIS");
+    console.log(`Decoded Japanese: "${japaneseDecoded}"`);
+    results.japaneseDecode = { decoded: japaneseDecoded };
+
+  } catch (error) {
+    console.error("Error in Japanese encode/decode:", error);
+    results.japaneseError = error;
+  }
+
+  try {
+    console.log("\n=== Special Encoding: HitachiKEIS90 ===");
+    const testStringKEIS = "HELLO(コンニチハ)";
+    console.log(`Converting "${testStringKEIS}" from UTF-8 to HitachiKEIS90`);
+
+    const convertedKEIS = tailor.iconv.convert(testStringKEIS, "UTF-8", "HitachiKEIS90//IGNORE");
+    console.log("Converted to HitachiKEIS90:", convertedKEIS);
+    results.hitachiKEIS90 = {
+      input: testStringKEIS,
+      fromEncoding: "UTF-8",
+      toEncoding: "HitachiKEIS90//IGNORE",
+      output: Array.from(convertedKEIS)
+    };
+
+  } catch (error) {
+    console.error("Error in HitachiKEIS90 conversion:", error);
+    results.hitachiKEIS90Error = error;
+  }
+
+  try {
+    console.log("\n=== Convert Between Different Encodings ===");
+    const mixedText = "ABC123あいうえお";
+
+    const shiftJIS = tailor.iconv.convert(mixedText, "UTF-8", "Shift_JIS");
+    console.log(`Converted "${mixedText}" to Shift_JIS:`, shiftJIS);
+    results.toShiftJIS = {
+      input: mixedText,
+      output: Array.from(shiftJIS)
+    };
+
+    const backToUTF8 = tailor.iconv.convert(shiftJIS, "Shift_JIS", "UTF-8");
+    console.log(`Converted back to UTF-8: "${backToUTF8}"`);
+    results.fromShiftJIS = {
+      input: Array.from(shiftJIS),
+      output: backToUTF8
+    };
+
+  } catch (error) {
+    console.error("Error in encoding conversion:", error);
+    results.conversionError = error;
+  }
+
+  try {
+    console.log("\n=== Check Encoding Availability ===");
+    const encodingList = tailor.iconv.encodings();
+    console.log(`Total available encodings: ${encodingList.length}`);
+
+    const hasUTF8 = encodingList.includes("UTF-8");
+    const hasEBCDICJPE = encodingList.includes("EBCDIC-JP-E");
+    const hasEBCDICJPKANA = encodingList.includes("EBCDIC-JP-KANA");
+    const hasIBM290 = encodingList.includes("IBM290");
+    const hasIBM930 = encodingList.includes("IBM930");
+    const hasShiftJIS = encodingList.includes("Shift_JIS");
+    const hasUTF16 = encodingList.includes("UTF-16");
+    const hasISO2022JP = encodingList.includes("ISO-2022-JP");
+
+    results.encodingAvailability = {
+      totalEncodings: encodingList.length,
+      "UTF-8": hasUTF8,
+      "EBCDIC-JP-E": hasEBCDICJPE,
+      "EBCDIC-JP-KANA": hasEBCDICJPKANA,
+      "IBM290": hasIBM290,
+      "IBM930": hasIBM930,
+      "Shift_JIS": hasShiftJIS,
+      "UTF-16": hasUTF16,
+      "ISO-2022-JP": hasISO2022JP
+    };
+
+    console.log("Encoding availability check:", results.encodingAvailability);
+
+    console.log("\n=== Sample of available encodings ===");
+    const sampleEncodings = encodingList.slice(0, 10);
+    console.log("First 10 encodings:", sampleEncodings);
+    results.sampleEncodings = sampleEncodings;
+
+  } catch (error) {
+    console.error("Error checking encoding availability:", error);
+    results.encodingCheckError = error;
+  }
+
+  try {
+    console.log("\n=== ISO-2022-JP Conversion Example ===");
+    const emailText = "Subject: テストメール";
+    const iso2022jp = tailor.iconv.convert(emailText, "UTF-8", "ISO-2022-JP");
+    console.log(`Converted "${emailText}" to ISO-2022-JP (common for emails):`, iso2022jp);
+    results.iso2022jp = {
+      input: emailText,
+      output: Array.from(iso2022jp)
+    };
+
+  } catch (error) {
+    console.error("Error in ISO-2022-JP conversion:", error);
+    results.iso2022jpError = error;
+  }
+
+  try {
+    console.log("\n=== EUC-JP Conversion Example ===");
+    const webText = "ウェブページのテキスト";
+    const eucjp = tailor.iconv.convert(webText, "UTF-8", "EUC-JP");
+    console.log(`Converted "${webText}" to EUC-JP:`, eucjp);
+    results.eucjp = {
+      input: webText,
+      output: Array.from(eucjp)
+    };
+
+    const eucjpBack = tailor.iconv.convert(eucjp, "EUC-JP", "UTF-8");
+    console.log(`Converted back from EUC-JP: "${eucjpBack}"`);
+    results.eucjpBack = eucjpBack;
+
+  } catch (error) {
+    console.error("Error in EUC-JP conversion:", error);
+    results.eucjpError = error;
+  }
+
+  try {
+    console.log("\n=== UTF-16 Conversion Example ===");
+    const unicodeText = "Unicode: 🌍🚀 日本語";
+    const utf16 = tailor.iconv.convert(unicodeText, "UTF-8", "UTF-16");
+    console.log(`Converted "${unicodeText}" to UTF-16:`, utf16);
+    results.utf16 = {
+      input: unicodeText,
+      output: Array.from(utf16)
+    };
+
+    const utf16Back = tailor.iconv.convert(utf16, "UTF-16", "UTF-8");
+    console.log(`Converted back from UTF-16: "${utf16Back}"`);
+    results.utf16Back = utf16Back;
+
+  } catch (error) {
+    console.error("Error in UTF-16 conversion:", error);
+    results.utf16Error = error;
+  }
+
+  try {
+    console.log("\n=== Error Handling with //IGNORE flag ===");
+    const problematicText = "Text with 特殊文字 that might not exist in target encoding";
+
+    const withIgnore = tailor.iconv.convert(problematicText, "UTF-8", "ASCII//IGNORE");
+    console.log(`Converted to ASCII with //IGNORE flag: "${withIgnore}"`);
+    results.withIgnore = {
+      input: problematicText,
+      output: btoa(String.fromCharCode(...new Uint8Array(withIgnore))),
+      note: "Non-ASCII characters were ignored"
+    };
+
+  } catch (error) {
+    console.error("Error in conversion with //IGNORE:", error);
+    results.ignoreError = error;
+  }
+
+  try {
+    console.log("\n=== Error Handling with //TRANSLIT flag ===");
+    const textToTranslit = "Café résumé naïve";
+
+    const withTranslit = tailor.iconv.convert(textToTranslit, "UTF-8", "ASCII//TRANSLIT");
+    console.log(`Converted to ASCII with //TRANSLIT flag: "${withTranslit}"`);
+    results.withTranslit = {
+      input: textToTranslit,
+      output: btoa(String.fromCharCode(...new Uint8Array(withTranslit))),
+      note: "Special characters were transliterated"
+    };
+
+  } catch (error) {
+    console.error("Error in conversion with //TRANSLIT:", error);
+    results.translitError = error;
+  }
+
+  console.log("\n=== All Examples Completed ===");
+
+  return {
+    message: "iconv examples executed successfully",
+    results: results
+  };
+};

--- a/examples/iconv/tsconfig.json
+++ b/examples/iconv/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@tsconfig/recommended/tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["@tailor-platform/function-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
This pull request adds a comprehensive example project for using the `tailor.iconv` APIs in Tailor Platform Functions. It includes example code for encoding/decoding, converting between various character encodings, error handling, and checking encoding availability. The project is fully set up with build scripts, TypeScript configuration, and all necessary dependencies.

The most important changes are:

**Example Implementation and Documentation**
* Added a detailed `README.md` explaining the usage of `tailor.iconv` APIs, including API reference, usage examples, and notes on error handling and encoding support.
* Implemented `src/index.ts` with multiple real-world examples demonstrating encoding, decoding, conversions between encodings (e.g., UTF-8, Shift_JIS, HitachiKEIS90, ISO-2022-JP, EUC-JP, UTF-16, ASCII), and error handling using `//IGNORE` and `//TRANSLIT` flags.

**Project Setup and Tooling**
* Added `package.json` with scripts and dev dependencies for TypeScript, esbuild, and Tailor function types, and included a `pnpm-lock.yaml` to lock dependency versions. [[1]](diffhunk://#diff-01e9e12944c0a1ca6a8538f4c20539f8efd9d484da28ace501fedebb40da7826R1-R16) [[2]](diffhunk://#diff-59bb700c6184117d9b59d9f0086c9f59bceea2e5a89575960f2549270dd3e34bR1-R311)
* Added a TypeScript configuration file `tsconfig.json` with strict settings and compatibility for the Tailor platform.
* Added a build script `build.mjs` using esbuild to bundle and minify the example code for deployment.