### PR TITLE
chore(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tailor-platform/maintainers-templates


### PR DESCRIPTION
This pull request makes a minor update to the `.github/CODEOWNERS` file, assigning ownership of all files to the `@tailor-platform/maintainers-templates` team.