### PR TITLE
feat: authconnection example

### DIFF
--- a/examples/authconnection/build.mjs
+++ b/examples/authconnection/build.mjs
@@ -1,0 +1,12 @@
+import { build } from "esbuild";
+
+build({
+  bundle: true,
+  entryPoints: ["src/index.ts"],
+  format: "esm",
+  outfile: "dist/index.js",
+  define: {
+    "global": "globalThis",
+  },
+  minify: false
+});

--- a/examples/authconnection/package.json
+++ b/examples/authconnection/package.json
@@ -1,0 +1,15 @@
+{
+  "description": "Exec tailor.authconnection APIs in the Function service",
+  "scripts": {
+    "build": "node ./build.mjs"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@tailor-platform/function-types": "^0.2.0",
+    "@tsconfig/recommended": "^1.0.8",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.7.3"
+  },
+  "packageManager": "pnpm@10.2.1"
+}

--- a/examples/authconnection/src/index.ts
+++ b/examples/authconnection/src/index.ts
@@ -1,0 +1,17 @@
+export default async () => {
+  // Get access token for a Google OAuth connection
+  const tokens = await tailor.authconnection.getConnectionToken('google-oauth');
+  // Use the access token to call Google APIs
+  const response = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+    headers: {
+      'Authorization': `Bearer ${tokens.access_token}`
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch user info: ${response.statusText}`);
+  }
+  const userInfo = await response.json();
+  console.log(userInfo);
+  return userInfo;
+}


### PR DESCRIPTION
This pull request introduces a new example project, `authconnection`, which demonstrates how to use the `tailor.authconnection` API to obtain a Google OAuth access token and fetch user information from Google. The main changes include adding the example's build configuration, dependencies, and implementation code.

**New Example Project: `authconnection`**

* Adds `src/index.ts` with an example function that retrieves a Google OAuth access token using `tailor.authconnection.getConnectionToken`, then fetches user info from the Google API and logs the result.
* Adds a build script using `esbuild` in `build.mjs` to bundle the TypeScript source into an ES module.
* Adds a `package.json` with relevant scripts and development dependencies for building and running the example.