### PR TITLE
chore: Add TailorDB file API usage example in function

### DIFF
--- a/examples/function-tailordb-file/README.md
+++ b/examples/function-tailordb-file/README.md
@@ -1,0 +1,80 @@
+# Tailor Platform TailorDB File Examples
+
+This directory contains comprehensive examples of using the TailorDB File APIs in Tailor Platform Functions.
+
+## Overview
+
+The TailorDB File API provides powerful file management capabilities for your applications, allowing you to:
+- Upload files of various types (text, binary, images)
+- Download files with metadata
+- Stream large files efficiently
+- Manage file metadata and lifecycle
+- Handle errors gracefully
+
+This example demonstrates a complete workflow from record creation to file operations, mirroring real-world usage patterns.
+
+## Prerequisites
+
+This example assumes a star-wars application with the following schema:
+
+### Required Schema
+
+The Starship type has two File fields:
+
+```cue
+// star-wars application schema
+Starship: {
+  Fields: {
+    name: { type: "String" }
+    serialNumber: { type: "String" }
+    status: { type: "String" }
+    isArmed: { type: "Boolean" }
+    crew: { type: "Int" }
+    capacity: { type: "Int" }
+    length: { type: "Float" }
+  }
+  Files: {
+    blueprint: tailordb.#File & {
+      Description: "Blueprint file of the starship"
+    }
+    thumbnail: tailordb.#File & {
+      Description: "Thumbnail image of the starship"
+    }
+  }
+}
+```
+
+## Example Files
+
+This directory contains both individual operation examples and a complete workflow example:
+
+### Individual Examples
+
+Each file focuses on a specific File API operation:
+
+- **setup.ts** - Create test record (preparation)
+- **01-upload.ts** - Upload files (text and binary)
+- **02-metadata.ts** - Get file metadata
+- **03-download.ts** - Download files
+- **04-streaming.ts** - Streaming download for large files
+- **05-delete.ts** - Delete files
+
+### Complete Workflow Example
+
+`index.ts` provides a comprehensive example combining all operations.
+
+### Running
+
+#### Run the Complete Example
+```bash
+# Build
+pnpm install
+pnpm build
+
+# Run
+tailorctl workspace function test-run -a star-wars -m r2d2 -s 'dist/index.js'
+```
+
+## Appendix
+
+- [Tailor Platform Documentation](https://docs.tailor.tech)

--- a/examples/function-tailordb-file/package.json
+++ b/examples/function-tailordb-file/package.json
@@ -1,0 +1,17 @@
+{
+  "description": "Examples of using TailorDB File APIs in the Function service",
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "build": "pnpm type-check && node ./build.mjs"
+  },
+  "dependencies": {
+    "@tailor-platform/function-logger": "^0.1.0"
+  },
+  "devDependencies": {
+    "@tailor-platform/function-types": "^0.6.0",
+    "@tsconfig/recommended": "^1.0.8",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.7.3"
+  },
+  "packageManager": "pnpm@10.2.1"
+}

--- a/examples/function-tailordb-file/src/01-upload.ts
+++ b/examples/function-tailordb-file/src/01-upload.ts
@@ -1,0 +1,96 @@
+import { logger } from "@tailor-platform/function-logger";
+import { formatError } from "./utils";
+
+/**
+ * Example: File Upload
+ *
+ * This example demonstrates how to upload files of different types:
+ * - Text files (blueprint)
+ * - Binary files (PNG image)
+ *
+ * Note: You need to provide a valid starshipId from the setup step.
+ */
+export default async (args: { starshipId: string }) => {
+  const { starshipId } = args;
+
+  if (!starshipId) {
+    return {
+      message: "starshipId is required",
+      error: "Please run setup.ts first to create a starship record",
+    };
+  }
+
+  const results: Record<string, any> = {};
+
+  // === Upload Text File (Blueprint) ===
+  logger.info("=== Uploading Blueprint (Text File) ===");
+
+  try {
+    const blueprintContent = "X-wing Fighter Blueprint\nEngine Type: Ion Drive\nWeapons: 4x Laser Cannons\nShields: Deflector Shield";
+
+    // Use TailorDB file API to upload file
+    // API throws TailorDBFileError on failure
+    const uploadResponse = await tailordb.file.upload(
+      "galaxy",
+      "Starship",
+      "blueprint",
+      starshipId,
+      blueprintContent,
+      { contentType: "text/plain" }
+    );
+
+    logger.info(`Uploaded blueprint: ${uploadResponse.metadata.fileSize} bytes`);
+    logger.info(`SHA256: ${uploadResponse.metadata.sha256sum}`);
+
+    results.blueprintUpload = {
+      fileSize: uploadResponse.metadata.fileSize,
+      sha256sum: uploadResponse.metadata.sha256sum,
+      contentType: "text/plain",
+    };
+  } catch (error) {
+    logger.error("Error in blueprint upload:", error);
+    results.blueprintUploadError = formatError(error);
+  }
+
+  // === Upload Binary File (Thumbnail Image) ===
+  logger.info("=== Uploading Thumbnail (Image File) ===");
+
+  try {
+    // Simulate a simple PNG image (PNG signature + minimal data)
+    const pngData = new Uint8Array([
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+      0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk header
+      0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // 1x1 pixel
+      0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, // bit depth, color type, etc.
+      0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, // IDAT chunk
+      0x54, 0x08, 0x99, 0x01, 0x01, 0x00, 0x00, 0x00, // minimal image data
+      0xFF, 0xFF, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01  // end of minimal data
+    ]);
+
+    // Upload binary image data
+    const imageUploadResponse = await tailordb.file.upload(
+      "galaxy",
+      "Starship",
+      "thumbnail",
+      starshipId,
+      pngData,
+      { contentType: "image/png" }
+    );
+
+    logger.info(`Uploaded thumbnail: ${imageUploadResponse.metadata.fileSize} bytes`);
+
+    results.thumbnailUpload = {
+      fileSize: imageUploadResponse.metadata.fileSize,
+      sha256sum: imageUploadResponse.metadata.sha256sum,
+      contentType: "image/png",
+    };
+  } catch (error) {
+    logger.error("Error in thumbnail upload:", error);
+    results.thumbnailUploadError = formatError(error);
+  }
+
+  return {
+    message: "File upload examples completed",
+    results,
+  };
+};

--- a/examples/function-tailordb-file/src/02-metadata.ts
+++ b/examples/function-tailordb-file/src/02-metadata.ts
@@ -1,0 +1,58 @@
+import { logger } from "@tailor-platform/function-logger";
+import { formatError } from "./utils";
+
+/**
+ * Example: File Metadata
+ *
+ * This example demonstrates how to retrieve file metadata without downloading the entire file.
+ * This is useful when you only need information about the file (size, content type, checksum, etc.)
+ *
+ * Note: You need to provide a valid starshipId with an uploaded file.
+ */
+export default async (args: { starshipId: string }) => {
+  const { starshipId } = args;
+
+  if (!starshipId) {
+    return {
+      message: "starshipId is required",
+      error: "Please run setup.ts and 01-upload.ts first",
+    };
+  }
+
+  logger.info("=== Get File Metadata ===");
+
+  try {
+    // Use TailorDB file API to get file metadata
+    // API returns metadata object directly, throws TailorDBFileError on failure
+    const metadata = await tailordb.file.getMetadata(
+      "galaxy",
+      "Starship",
+      "blueprint",
+      starshipId
+    );
+
+    // Success case - API guarantees metadata is present and valid
+    logger.info("File metadata:");
+    logger.info(`  Content Type: ${metadata.contentType}`);
+    logger.info(`  File Size: ${metadata.fileSize} bytes`);
+    logger.info(`  SHA256: ${metadata.sha256sum}`);
+    if (metadata.lastUploadedAt) {
+      logger.info(`  Last Uploaded: ${metadata.lastUploadedAt}`);
+    }
+
+    return {
+      message: "File metadata retrieved successfully",
+      contentType: metadata.contentType,
+      fileSize: metadata.fileSize,
+      sha256sum: metadata.sha256sum,
+      lastUploadedAt: metadata.lastUploadedAt,
+    };
+  } catch (error) {
+    logger.error("Error getting metadata:", error);
+
+    return {
+      message: "Failed to get file metadata",
+      error: formatError(error),
+    };
+  }
+};

--- a/examples/function-tailordb-file/src/03-download.ts
+++ b/examples/function-tailordb-file/src/03-download.ts
@@ -1,0 +1,55 @@
+import { logger } from "@tailor-platform/function-logger";
+import { formatError } from "./utils";
+
+/**
+ * Example: File Download
+ *
+ * This example demonstrates how to download a file and access its content and metadata.
+ *
+ * Note: You need to provide a valid starshipId with an uploaded file.
+ */
+export default async (args: { starshipId: string }) => {
+  const { starshipId } = args;
+
+  if (!starshipId) {
+    return {
+      message: "starshipId is required",
+      error: "Please run setup.ts and 01-upload.ts first",
+    };
+  }
+
+  logger.info("=== File Download ===");
+
+  try {
+    // Use TailorDB file API to download file
+    // If download fails, it will throw TailorDBFileError
+    const downloadResponse = await tailordb.file.download(
+      "galaxy",
+      "Starship",
+      "blueprint",
+      starshipId
+    );
+
+    // Success case - API guarantees metadata is present
+    logger.info(`Downloaded file: ${downloadResponse.metadata.fileSize} bytes`);
+    logger.info(`Content type: ${downloadResponse.metadata.contentType}`);
+
+    // Convert Uint8Array back to string for text files
+    const downloadedText = new TextDecoder().decode(downloadResponse.data);
+    logger.info(`Content preview: ${downloadedText}`);
+
+    return {
+      message: "File download completed successfully",
+      fileSize: downloadResponse.metadata.fileSize,
+      contentType: downloadResponse.metadata.contentType,
+      contentPreview: downloadedText,
+    };
+  } catch (error) {
+    logger.error("Error in download:", error);
+
+    return {
+      message: "File download failed",
+      error: formatError(error),
+    };
+  }
+};

--- a/examples/function-tailordb-file/src/04-streaming.ts
+++ b/examples/function-tailordb-file/src/04-streaming.ts
@@ -1,0 +1,135 @@
+import { logger } from "@tailor-platform/function-logger";
+import { formatError } from "./utils";
+
+/**
+ * Example: Streaming Download for Large Files
+ *
+ * This example demonstrates how to efficiently download large files using streaming.
+ * Streaming is useful when dealing with files that are too large to fit in memory at once.
+ *
+ * Note: You need to provide a valid starshipId. This example will upload a large file first.
+ */
+export default async (args: { starshipId: string }) => {
+  const { starshipId } = args;
+
+  if (!starshipId) {
+    return {
+      message: "starshipId is required",
+      error: "Please run setup.ts first",
+    };
+  }
+
+  logger.info("=== Streaming Download Demo ===");
+
+  try {
+    // First, upload a larger file for streaming demonstration
+    logger.info("Uploading larger file for streaming demo...");
+    const largeContent = "Large starship blueprint content\n".repeat(1000); // ~34KB
+
+    await tailordb.file.upload(
+      "galaxy",
+      "Starship",
+      "blueprint",
+      starshipId,
+      largeContent,
+      { contentType: "text/plain" }
+    );
+
+    logger.info("Uploaded large file, now streaming download...");
+
+    // Open stream using iterator pattern for efficient memory usage
+    const stream = await tailordb.file.openDownloadStream(
+      "galaxy",
+      "Starship",
+      "blueprint",
+      starshipId
+    );
+
+    let totalBytes = 0;
+    let chunkCount = 0;
+    let streamMetadata: any = null;
+    let reconstructedData: Uint8Array | null = null;
+    let offset = 0;
+
+    try {
+      // Using for-await-of loop to process chunks as they arrive
+      for await (const chunkResult of stream) {
+        switch (chunkResult.type) {
+          case 'metadata':
+            streamMetadata = chunkResult.metadata;
+            logger.info(`Stream started: ${chunkResult.metadata.fileSize} bytes`);
+            logger.info(`Content type: ${chunkResult.metadata.contentType}`);
+
+            // Pre-allocate buffer based on file size for maximum memory efficiency
+            if (chunkResult.metadata.fileSize > 0) {
+              reconstructedData = new Uint8Array(chunkResult.metadata.fileSize);
+            }
+            break;
+
+          case 'chunk':
+            const chunk = new Uint8Array(chunkResult.data);
+
+            // Verify position matches expected next offset
+            // position represents the end of this chunk in the file
+            const expectedPosition = offset + chunk.length;
+            if (chunkResult.position !== undefined && chunkResult.position !== expectedPosition) {
+              throw new Error(
+                `Position mismatch: expected ${expectedPosition} (offset ${offset} + chunk size ${chunk.length}), but got ${chunkResult.position}`
+              );
+            }
+
+            totalBytes += chunk.length;
+            chunkCount++;
+
+            // Reconstruct data chunk by chunk
+            if (reconstructedData) {
+              reconstructedData.set(chunk, offset);
+              offset += chunk.length;
+            }
+
+            logger.info(`Chunk ${chunkCount}: ${chunk.length} bytes at position ${chunkResult.position}`);
+            break;
+
+          case 'complete':
+            logger.info(`Stream completed. Total: ${totalBytes} bytes in ${chunkCount} chunks`);
+            break;
+        }
+      }
+
+      // Verify the download
+      const expectedSize = streamMetadata?.fileSize || 0;
+      const isValid = expectedSize === 0 || totalBytes === expectedSize;
+
+      if (!isValid) {
+        logger.warn(`Size mismatch: expected ${expectedSize} bytes, got ${totalBytes} bytes`);
+      }
+
+      // Convert reconstructed data back to string for verification
+      let reconstructedContent = "";
+      if (reconstructedData && offset > 0) {
+        const textDecoder = new TextDecoder();
+        reconstructedContent = textDecoder.decode(reconstructedData.slice(0, offset));
+      }
+
+      return {
+        message: "Streaming download completed successfully",
+        totalBytes,
+        chunkCount,
+        metadata: streamMetadata,
+        completed: true,
+        isValid,
+        contentPreview: reconstructedContent.substring(0, 100),
+      };
+    } finally {
+      // Always cleanup stream resources
+      await stream.close();
+    }
+  } catch (error) {
+    logger.error("Error in streaming download:", error);
+
+    return {
+      message: "Streaming download failed",
+      error: formatError(error),
+    };
+  }
+};

--- a/examples/function-tailordb-file/src/05-delete.ts
+++ b/examples/function-tailordb-file/src/05-delete.ts
@@ -1,0 +1,48 @@
+import { logger } from "@tailor-platform/function-logger";
+import { formatError } from "./utils";
+
+/**
+ * Example: File Deletion
+ *
+ * This example demonstrates how to delete a file.
+ *
+ * Note: You need to provide a valid starshipId with an uploaded file.
+ */
+export default async (args: { starshipId: string }) => {
+  const { starshipId } = args;
+
+  if (!starshipId) {
+    return {
+      message: "starshipId is required",
+      error: "Please run setup.ts and 01-upload.ts first",
+    };
+  }
+
+  logger.info("=== File Deletion ===");
+
+  try {
+    // Use TailorDB file API to delete file
+    // If deletion fails, it will throw a TailorDBFileError
+    await tailordb.file.delete(
+      "galaxy",
+      "Starship",
+      "thumbnail",
+      starshipId
+    );
+
+    logger.info("Thumbnail file deleted successfully");
+
+    return {
+      message: "File deletion completed successfully",
+      success: true,
+      deletedField: "thumbnail",
+    };
+  } catch (error) {
+    logger.error("Error in file deletion:", error);
+
+    return {
+      message: "File deletion failed",
+      error: formatError(error),
+    };
+  }
+};

--- a/examples/function-tailordb-file/src/index.ts
+++ b/examples/function-tailordb-file/src/index.ts
@@ -1,0 +1,60 @@
+import { logger } from "@tailor-platform/function-logger";
+import setup from "./setup";
+import upload from "./01-upload";
+import metadata from "./02-metadata";
+import download from "./03-download";
+import streaming from "./04-streaming";
+import deleteFile from "./05-delete";
+
+/**
+ * Comprehensive TailorDB File API Examples
+ *
+ * This example demonstrates all File API operations in a single workflow:
+ * 1. Setup: Create a test Starship record
+ * 2. Upload: Upload text and binary files
+ * 3. Metadata: Retrieve file metadata
+ * 4. Download: Download files and access content
+ * 5. Streaming: Download large files efficiently
+ * 6. Delete: Remove files
+ *
+ * For individual examples, see the separate files: setup.ts, 01-upload.ts, etc.
+ */
+export default async () => {
+  logger.info("Starting TailorDB File API examples");
+
+  // 1. Setup
+  const setupResult = await setup();
+  if ("error" in setupResult || !setupResult.starshipId) {
+    return setupResult;
+  }
+  const starshipId = setupResult.starshipId;
+
+  // 2. Upload
+  const uploadResult = await upload({ starshipId });
+
+  // 3. Metadata
+  const metadataResult = await metadata({ starshipId });
+
+  // 4. Download
+  const downloadResult = await download({ starshipId });
+
+  // 5. Streaming
+  const streamingResult = await streaming({ starshipId });
+
+  // 6. Delete
+  const deleteResult = await deleteFile({ starshipId });
+
+  logger.info("\n=== TailorDB File API Examples Completed ===");
+
+  return {
+    message: "TailorDB File API examples executed successfully",
+    results: {
+      setup: setupResult,
+      upload: uploadResult,
+      metadata: metadataResult,
+      download: downloadResult,
+      streaming: streamingResult,
+      deletion: deleteResult
+    }
+  };
+};

--- a/examples/function-tailordb-file/src/setup.ts
+++ b/examples/function-tailordb-file/src/setup.ts
@@ -1,0 +1,55 @@
+import { logger } from "@tailor-platform/function-logger";
+
+/**
+ * Example: Setup - Create Test Starship Record
+ *
+ * This example demonstrates how to create a test Starship record
+ * that will be used for file operations in subsequent examples.
+ */
+export default async () => {
+  logger.info("=== Setup: Creating Test Starship Record ===");
+
+  try {
+    const client = new tailordb.Client({ namespace: "galaxy" });
+    await client.connect();
+
+    // Create a test starship record
+    const createResult = await client.queryObject<{ id: string; name: string }>(
+      `INSERT INTO "Starship" (name, "serialNumber", status, "isArmed", crew, capacity, length)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id, name`,
+      [
+        "File API Test X-wing",
+        "12345678-1234-5678-9abc-123456789abc",
+        "ACTIVE",
+        true,
+        1,
+        1,
+        12.5
+      ]
+    );
+
+    if (createResult.rows.length === 0) {
+      throw new Error("Failed to create starship record");
+    }
+
+    const starship = createResult.rows[0];
+    logger.info(`Created test starship: ${starship.name} (ID: ${starship.id})`);
+
+    await client.end();
+
+    return {
+      message: "Setup completed successfully",
+      starshipId: starship.id,
+      name: starship.name,
+    };
+  } catch (error) {
+    logger.error("Setup error:", error);
+    logger.error("Make sure the star-wars application is deployed with the correct Starship schema");
+
+    return {
+      message: "Setup failed",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+};

--- a/examples/function-tailordb-file/src/utils.ts
+++ b/examples/function-tailordb-file/src/utils.ts
@@ -1,0 +1,18 @@
+// Type guard to help with error handling
+export function isError(error: unknown): error is Error {
+  return error instanceof Error;
+}
+
+// Helper to format error for results
+export function formatError(error: unknown) {
+  if (error instanceof TailorDBFileError) {
+    return {
+      name: error.name,
+      message: error.message,
+      code: error.code,
+    };
+  }
+  return {
+    message: isError(error) ? error.message : String(error),
+  };
+}

--- a/examples/function-tailordb-file/tsconfig.json
+++ b/examples/function-tailordb-file/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@tsconfig/recommended/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "types": ["@tailor-platform/function-types"]
+  }
+}


### PR DESCRIPTION
This PR adds a new example to demonstrate how to use TailorDB file types from the function package. This example provides developers with a concrete reference for integrating TailorDB file operations in their own functions, making it easier to adopt the new type definitions introduced in @tailor-platform/function-types@0.6.0.

Details
* Introduced examples/function-tailordb-file
* Covers end-to-end usage of TailorDB file API:
    * File upload with metadata
    * Retrieving file metadata
    * Streaming download for large files
    * File deletion